### PR TITLE
Fix precompile array conversion

### DIFF
--- a/src/evm_mo_backend/precompiles.mo
+++ b/src/evm_mo_backend/precompiles.mo
@@ -127,7 +127,9 @@ module {
     // Function to convert Nat8 array to an array of little-endian 8-byte words
     func arrayN8toN64LE(arr: [Nat8]) : [Nat64] {
         var output = [] : [Nat64];
-        if (arr.size() < 8) { () };
+        if (arr.size() < 8) {
+            return output;
+        };
         for (i in Iter.range(0, arr.size() / 8 - 1)) {
             let subarr = Array.subArray<Nat8>(arr, i * 8, 8);
             var x = 0;


### PR DESCRIPTION
## Summary
- guard `arrayN8toN64LE` against short arrays to avoid range underflow

## Testing
- `npm test` *(fails: could not find package.json)*
- `mops test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880f2edc4248327bf85f16e47dd889e